### PR TITLE
Update MiniZincDistribution.jsx: fixed link to Gecode website

### DIFF
--- a/src/components/downloads/MiniZincDistribution.jsx
+++ b/src/components/downloads/MiniZincDistribution.jsx
@@ -40,7 +40,7 @@ export function MiniZincDistribution() {
             </p>
             <ul className="mx-2 my-2 list-inside list-disc leading-relaxed">
               <li>
-                <Link href="https://www.gecode.org">Gecode</Link>
+                <Link href="https://www.gecode.dev/">Gecode</Link>
               </li>
               <li>
                 <Link href="https://github.com/chuffed/chuffed">Chuffed</Link>


### PR DESCRIPTION
The link to www.gecode.org is bad. The website has a self-signed certificate that leads to browser alerts and once one navigates those, has apparently a nonfunction redirect. The new website is www.gecode.dev it seems